### PR TITLE
Add cron schedule for weekly Docker build

### DIFF
--- a/.github/workflows/docker-build-cloud.yml
+++ b/.github/workflows/docker-build-cloud.yml
@@ -2,6 +2,8 @@ name: docker-build-cloud
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # 毎週日曜日の午前0時（UTC）
 
 jobs:
   build-cloud:


### PR DESCRIPTION
Add a scheduled trigger to the Docker build workflow.